### PR TITLE
Make AWS credentials optional in the configuration file.

### DIFF
--- a/cbeventforwarder/lib/event_processor.py
+++ b/cbeventforwarder/lib/event_processor.py
@@ -146,7 +146,10 @@ class S3Output(EventOutput):
 
         # s3 creds must be defined either in an environment variable, boto config
         # or EC2 instance metadata.
-        self.conn = boto.connect_s3(aws_access_key_id=key, aws_secret_access_key=secret)
+        if not key or not secret:
+            self.conn = boto.connect_s3()
+        else:
+            self.conn = boto.connect_s3(aws_access_key_id=key, aws_secret_access_key=secret)
 
         self.bucket = self.conn.get_bucket(bucket)
         self.temp_file_location = temp_file_location
@@ -224,7 +227,7 @@ class EventProcessor(object):
             (host, port) = options.get("udpout").split(":")
             self.output = UdpOutput(host, int(port))
         elif output_type == "s3":
-            self.output = S3Output(options.get("s3out"), options.get("aws_key"), options.get("aws_secret"))
+            self.output = S3Output(options.get("s3out"), options.get("aws_key", None), options.get("aws_secret", None))
         else:
             raise ValueError("Invalid output type: %s" % output_type)
 

--- a/root/etc/cb/integrations/event-forwarder/cb-event-forwarder.conf.example
+++ b/root/etc/cb/integrations/event-forwarder/cb-event-forwarder.conf.example
@@ -59,11 +59,11 @@ udpout=None
 
 # options for S3 support
 # s3out: The s3 bucket name
-# aws_key: The aws access key id
-# aws_scret: The aws secret access key
+# aws_key: The aws access key id. Leave blank to use the boto standard credential search path
+# aws_secret: The aws secret access key. Leave blank to use the boto standard credential search path
 s3out=None
-aws_key=None
-aws_secret=None
+aws_key=
+aws_secret=
 
 #########
 # Configuration for which events are captured


### PR DESCRIPTION
If AWS credentials are not found in the event-forwarder
configuration file, then use the boto library standard
search path to find them.