### PR TITLE
Fix parsing of UseRawSensorExchange configuration parameter

### DIFF
--- a/amqp.go
+++ b/amqp.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/streadway/amqp"
 	"log"
+
+	"github.com/streadway/amqp"
 )
 
 /*
@@ -70,10 +71,6 @@ func NewConsumer(amqpURI, queueName, ctag string, bindToRawExchange bool,
 		return nil, nil, fmt.Errorf("Queue declare: %s", err)
 	}
 
-	err = c.channel.QueueBind(queueName, "#", "api.events", false, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("QueueBind: %s", err)
-	}
 	if bindToRawExchange {
 		err = c.channel.QueueBind(queueName, "", "api.rawsensordata", false, nil)
 		if err != nil {

--- a/config.go
+++ b/config.go
@@ -4,10 +4,11 @@ import (
 	"errors"
 	_ "expvar"
 	"fmt"
-	"github.com/vaughan0/go-ini"
 	"log"
 	"strconv"
 	"strings"
+
+	"github.com/vaughan0/go-ini"
 )
 
 const (
@@ -329,7 +330,7 @@ func ParseConfig(fn string) (Configuration, error) {
 	val, ok = input.Get("bridge", "use_raw_sensor_exchange")
 	if ok {
 		boolval, err := strconv.ParseBool(val)
-		if err == nil && boolval {
+		if err == nil {
 			log.Println("Configured to listen on the Carbon Black Enterprise Response raw sensor event feed.")
 			log.Println("- This will result in a *large* number of messages output via the event forwarder!")
 			log.Println("- Ensure that raw sensor events are enabled in your Cb server (master & minion) via")


### PR DESCRIPTION
Without this change when you set "use_raw_sensor_exchange" to false and try to start the event forwarder it fails and you are told that the valid values are "true, false, 1, 0"