### PR TITLE
Fix directionality in LEEF output

### DIFF
--- a/config.go
+++ b/config.go
@@ -94,16 +94,13 @@ func (c *Configuration) parseEventTypes(input ini.File) {
 		eventList []string
 	}{
 		{"events_watchlist", []string{
-			"watchlist.hit.#",
-			"watchlist.storage.hit.#",
+			"watchlist.#",
 		}},
 		{"events_feed", []string{
-			"feed.ingress.hit.#",
-			"feed.storage.hit.#",
-			"feed.query.hit.#",
+			"feed.#",
 		}},
 		{"events_alert", []string{
-			"alert.watchlist.hit.#",
+			"alert.#",
 		}},
 		{"events_raw_sensor", []string{
 			"ingress.event.process",
@@ -125,7 +122,7 @@ func (c *Configuration) parseEventTypes(input ini.File) {
 			"binaryinfo.#",
 		}},
 		{"events_binary_upload", []string{
-			"binarystore.file.added",
+			"binarystore.#",
 		}},
 	}
 

--- a/json_message_processor.go
+++ b/json_message_processor.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/carbonblack/cb-event-forwarder/deepcopy"
-	"log"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -132,8 +131,6 @@ func fixupMessage(messageType string, msg map[string]interface{}) {
 					msg["process_guid"] = processGuid
 					msg["segment_id"] = fmt.Sprintf("%v", segment)
 					hasProcessGUID = true
-				} else {
-					log.Printf("wtf? %v", value)
 				}
 			}
 		}

--- a/leef/leef_encoder.go
+++ b/leef/leef_encoder.go
@@ -12,9 +12,9 @@ import (
 
 var (
 	productVendorName string
-	productName string
-	productVersion string
-	leefVersion string
+	productName       string
+	productVersion    string
+	leefVersion       string
 	formatter         *strings.Replacer
 )
 
@@ -44,19 +44,31 @@ func generateHeader(cbVersion, eventType string) string {
 }
 
 func normalizeAddToMap(msg map[string]interface{}, temp map[string]interface{}) {
+	outboundConnections := map[string]string{
+		"local_ip":    "src",
+		"remote_ip":   "dst",
+		"protocol":    "proto",
+		"local_port":  "srcPort",
+		"remote_port": "dstPort",
+	}
+	inboundConnections := map[string]string{
+		"local_ip":    "dst",
+		"remote_ip":   "src",
+		"protocol":    "proto",
+		"local_port":  "dstPort",
+		"remote_port": "srcPort",
+	}
+
+	leefMap := outboundConnections
+	if directionality, ok := temp["direction"]; ok {
+		if directionality == "inbound" {
+			leefMap = inboundConnections
+		}
+	}
+
 	for key, value := range temp {
-		switch key {
-		// break is implicit in golang
-		case "local_ip":
-			msg["src"] = value
-		case "remote_ip":
-			msg["dst"] = value
-		case "protocol":
-			msg["proto"] = value
-		case "local_port":
-			msg["srcPort"] = value
-		case "remote_port":
-			msg["dstPort"] = value
+		if newKey, ok := leefMap[key]; ok {
+			msg[newKey] = value
 		}
 	}
 }
@@ -144,7 +156,6 @@ func Encode(msg map[string]interface{}) (string, error) {
 			}
 		}
 	}
-
 
 	//
 	// For netconns we want to map remote and local ports to QRadar normalized fields

--- a/leef/leef_encoder.go
+++ b/leef/leef_encoder.go
@@ -230,5 +230,10 @@ func Encode(msg map[string]interface{}) (string, error) {
 		kvPairs = append(kvPairs, fmt.Sprintf("%s=%s", key, val))
 	}
 
+	// override "procstart" with "process" as this is what the LEEF decoder in QRadar is expecting
+	if messageType == "ingress.event.procstart" {
+		messageType = "ingress.event.process"
+	}
+
 	return fmt.Sprintf("%s%s", generateHeader(cbVersion, messageType), strings.Join(kvPairs, "\t")), nil
 }


### PR DESCRIPTION
`src` and `dst` IP addresses and ports were reversed in the LEEF output when processing netconn data from inbound connections