### PR TITLE
Add milliseconds to filenames so they are less likely to collide

### DIFF
--- a/bundled_output.go
+++ b/bundled_output.go
@@ -184,7 +184,7 @@ func (o *BundledOutput) rollOver() error {
 		return nil
 	}
 
-	fn, err := o.tempFileOutput.rollOverFile("2006-01-02T15:04:05")
+	fn, err := o.tempFileOutput.rollOverFile("2006-01-02T15:04:05.000Z")
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Output files can get created with the same filename and when uploaded to S3, they overwrite each other. This results in a loss of data for consumers.