### PR TITLE
TLS CN override

### DIFF
--- a/cb_api.go
+++ b/cb_api.go
@@ -4,12 +4,12 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"github.com/zvelo/ttlru"
 	"io/ioutil"
 	"net/http"
-	"github.com/zvelo/ttlru"
+	"net/url"
 	"strconv"
 	"time"
-	"net/url"
 )
 
 type ThreatReport struct {
@@ -27,29 +27,30 @@ type ThreatReport struct {
 }
 
 type ApiInfo struct {
-	BanningEnabled          bool            `json:"banningEnabled"`
-	BinaryOrder             string          `json:"binaryOrder"`
-	BinaryPageSize          int             `json:"binaryPageSize"`
-	CBLREnabled             bool 		`json:"cblrEnabled"`
-	CloudInstall            bool  		`json:"cloud_install"`
-	Features                interface{} 	`json:"features"`
-	LinuxInstallerExists    bool 		`json:"linuxInstallerExists"`
-	MaxRowsSolrReportQuery  int 		`json:"maxRowsSolrReportQuery"`
-	MaxSearchResultRows     int 		`json:"maxSearchResultRows"`
-	OsxInstallerExists      bool        	`json:"osxInstallerExists"`
-	ProcessOrder            string        	`json:"processOrder"`
-	ProcessPageSize         int        	`json:"processPageSize"`
-	SearchExportCount       int        	`json:"searchExportCount"`
-	TimestampDeltaThreshold int        	`json:"timestampDeltaThreshold"`
-	VdiGloballyEnabled      bool        	`json:"vdiGloballyEnabled"`
-	Version                 string 		`json:"version"`
-	VersionRelease          string        	`json:"version_release"`
+	BanningEnabled          bool        `json:"banningEnabled"`
+	BinaryOrder             string      `json:"binaryOrder"`
+	BinaryPageSize          int         `json:"binaryPageSize"`
+	CBLREnabled             bool        `json:"cblrEnabled"`
+	CloudInstall            bool        `json:"cloud_install"`
+	Features                interface{} `json:"features"`
+	LinuxInstallerExists    bool        `json:"linuxInstallerExists"`
+	MaxRowsSolrReportQuery  int         `json:"maxRowsSolrReportQuery"`
+	MaxSearchResultRows     int         `json:"maxSearchResultRows"`
+	OsxInstallerExists      bool        `json:"osxInstallerExists"`
+	ProcessOrder            string      `json:"processOrder"`
+	ProcessPageSize         int         `json:"processPageSize"`
+	SearchExportCount       int         `json:"searchExportCount"`
+	TimestampDeltaThreshold int         `json:"timestampDeltaThreshold"`
+	VdiGloballyEnabled      bool        `json:"vdiGloballyEnabled"`
+	Version                 string      `json:"version"`
+	VersionRelease          string      `json:"version_release"`
 }
+
 /*
  * This is the Cache for the report title within post processing
  * Mapping: "<feed_id>|<report_id>" -> report_title
  */
-var FeedCache = ttlru.New(128, 5 * time.Minute)
+var FeedCache = ttlru.New(128, 5*time.Minute)
 
 func GetCb(route string) ([]byte, error) {
 
@@ -69,8 +70,8 @@ func GetCb(route string) ([]byte, error) {
 	}
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: !config.CbAPIVerifySSL},
-		Proxy: proxyRequest,
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: !config.CbAPIVerifySSL, MinVersion: tls.VersionTLS12},
+		Proxy:           proxyRequest,
 	}
 
 	httpClient := &http.Client{Transport: tr}
@@ -86,7 +87,7 @@ func GetCb(route string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200{
+	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("Cb Response Server returned a %d status code.\n", resp.StatusCode)
 	}
 

--- a/conf/cb-event-forwarder.example.ini
+++ b/conf/cb-event-forwarder.example.ini
@@ -317,6 +317,11 @@ events_binary_upload=ALL
 # when using TLS+TCP syslog
 # tls_verify=false
 
+# Uncomment insecure_tls to allow connections to servers that only support TLS versions less than 1.2.
+# The default is to only support TLSv1.2 cipher suites. This option will allow connections to TLSv1.0 and 1.1
+# servers as well.
+# insecure_tls=true
+
 # Uncomment client_key and client_cert and set to files containing PEM-encoded private key and public
 # certificate when using client TLS certificates when using TLS+TCP syslog
 # client_key=/etc/cb/integrations/event-forwarder/client-key.pem
@@ -362,6 +367,11 @@ events_binary_upload=ALL
 
 # Uncomment tls_verify and set to "false" in order to disable verification of the peer server certificate
 # tls_verify=false
+
+# Uncomment insecure_tls to allow connections to servers that only support TLS versions less than 1.2.
+# The default is to only support TLSv1.2 cipher suites. This option will allow connections to TLSv1.0 and 1.1
+# servers as well.
+# insecure_tls=true
 
 # Uncomment client_key and client_cert and set to files containing PEM-encoded private key and public
 #  certificate when using client TLS certificates

--- a/conf/cb-event-forwarder.example.ini
+++ b/conf/cb-event-forwarder.example.ini
@@ -308,6 +308,11 @@ events_binary_upload=ALL
 # server when using TLS+TCP syslog
 # ca_cert=/etc/cb/integrations/event-forwarder/ca-certs.pem
 
+# Uncomment server_cname to force a specific server Common Name when validating the peer server
+# certificate. Useful for situations where the peer server is using a self-signed certificate with
+# a generic name (for example, QRadar's default certificate uses "*" as the CN)
+# server_cname=peer.server.name
+
 # Uncomment tls_verify and set to "false" in order to disable verification of the peer server certificate
 # when using TLS+TCP syslog
 # tls_verify=false
@@ -349,6 +354,11 @@ events_binary_upload=ALL
 
 # Uncomment ca_cert to specify a file containing PEM-encoded CA certificates for verifying the peer server
 # ca_cert=/etc/cb/integrations/event-forwarder/ca-certs.pem
+
+# Uncomment server_cname to force a specific server Common Name when validating the peer server
+# certificate. Useful for situations where the peer server is using a self-signed certificate with
+# a generic name (for example, QRadar's default certificate uses "*" as the CN)
+# server_cname=peer.server.name
 
 # Uncomment tls_verify and set to "false" in order to disable verification of the peer server certificate
 # tls_verify=false

--- a/config.go
+++ b/config.go
@@ -44,6 +44,7 @@ type Configuration struct {
 	AMQPTLSCACert        string
 	OutputParameters     string
 	EventTypes           []string
+	EventMap             map[string]bool
 	HTTPServerPort       int
 	CbServerURL          string
 	UseRawSensorExchange bool
@@ -77,7 +78,7 @@ type Configuration struct {
 	PerformFeedPostprocessing bool
 	CbAPIToken                string
 	CbAPIVerifySSL            bool
-	CbAPIProxyUrl	          string
+	CbAPIProxyUrl             string
 }
 
 type ConfigurationError struct {
@@ -156,11 +157,6 @@ func (c *Configuration) parseEventTypes(input ini.File) {
 	}
 
 	for _, eventType := range eventTypes {
-		if eventType.configKey == "events_raw_sensor" && c.UseRawSensorExchange {
-			// skip the sensor event section if we're consuming from the firehose anyway
-			// we will be forwarding everything in that case
-			continue
-		}
 		val, ok := input.Get("bridge", eventType.configKey)
 		if ok {
 			val = strings.ToLower(val)
@@ -176,6 +172,12 @@ func (c *Configuration) parseEventTypes(input ini.File) {
 				}
 			}
 		}
+	}
+
+	c.EventMap = make(map[string]bool)
+
+	for _, eventName := range c.EventTypes {
+		c.EventMap[eventName] = true
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -557,11 +557,12 @@ func configureTLS(config Configuration) *tls.Config {
 	}
 
 	if config.TLSCName != nil && len(*config.TLSCName) > 0 {
-		log.Printf("Forcing TLS Common Name check to use %s.", *config.TLSCName)
+		log.Printf("Forcing TLS Common Name check to use '%s' as the hostname", *config.TLSCName)
 		tlsConfig.ServerName = *config.TLSCName
 	}
 
 	if config.TLS12Only == true {
+		log.Println("Enforcing minimum TLS version 1.2")
 		tlsConfig.MinVersion = tls.VersionTLS12
 	} else {
 		log.Println("Relaxing minimum TLS version to 1.0")

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"time"
 )
 
+import _ "net/http/pprof"
+
 var (
 	checkConfiguration = flag.Bool("check", false, "Check the configuration file and exit")
 	debug              = flag.Bool("debug", false, "Enable debugging mode")

--- a/pb_message_processor.go
+++ b/pb_message_processor.go
@@ -221,32 +221,79 @@ func ProcessProtobufMessage(routingKey string, body []byte, headers amqp.Table) 
 
 	switch {
 	case cbMessage.Process != nil:
-		WriteProcessMessage(inmsg, outmsg)
+		if _, ok := config.EventMap["ingress.event.process"]; ok {
+			WriteProcessMessage(inmsg, outmsg)
+		} else if _, ok := config.EventMap["ingress.event.procstart"]; ok {
+			WriteProcessMessage(inmsg, outmsg)
+		} else {
+			return nil, nil
+		}
 	case cbMessage.Modload != nil:
-		WriteModloadMessage(inmsg, outmsg)
+		if _, ok := config.EventMap["ingress.event.moduleload"]; ok {
+			WriteModloadMessage(inmsg, outmsg)
+		} else {
+			return nil, nil
+		}
 	case cbMessage.Filemod != nil:
-		WriteFilemodMessage(inmsg, outmsg)
+		if _, ok := config.EventMap["ingress.event.filemod"]; ok {
+			WriteFilemodMessage(inmsg, outmsg)
+		} else {
+			return nil, nil
+		}
+
 	case cbMessage.Network != nil:
-		WriteNetconnMessage(inmsg, outmsg)
+		if _, ok := config.EventMap["ingress.event.netconn"]; ok {
+			WriteNetconnMessage(inmsg, outmsg)
+		} else {
+			return nil, nil
+		}
 	case cbMessage.Regmod != nil:
-		WriteRegmodMessage(inmsg, outmsg)
+		if _, ok := config.EventMap["ingress.event.regmod"]; ok {
+			WriteRegmodMessage(inmsg, outmsg)
+		} else {
+			return nil, nil
+		}
 	case cbMessage.Childproc != nil:
-		WriteChildprocMessage(inmsg, outmsg)
+		if _, ok := config.EventMap["ingress.event.childproc"]; ok {
+			WriteChildprocMessage(inmsg, outmsg)
+		} else {
+			return nil, nil
+		}
 	case cbMessage.Crossproc != nil:
-		WriteCrossProcMessage(inmsg, outmsg)
+		if _, ok := config.EventMap["ingress.event.crossprocopen"]; ok {
+			WriteCrossProcMessage(inmsg, outmsg)
+		} else {
+			return nil, nil
+		}
 	case cbMessage.Emet != nil:
-		WriteEmetEvent(inmsg, outmsg)
+		if _, ok := config.EventMap["ingress.event.emetmitigation"]; ok {
+			WriteEmetEvent(inmsg, outmsg)
+		} else {
+			return nil, nil
+		}
 	case cbMessage.NetconnBlocked != nil:
 		WriteNetconnBlockedMessage(inmsg, outmsg)
 	case cbMessage.TamperAlert != nil:
-		eventMsg = false
-		WriteTamperAlertMsg(inmsg, outmsg)
+		if _, ok := config.EventMap["ingress.event.tamper"]; ok {
+			eventMsg = false
+			WriteTamperAlertMsg(inmsg, outmsg)
+		} else {
+			return nil, nil
+		}
 	case cbMessage.Blocked != nil:
-		eventMsg = false
-		WriteProcessBlockedMsg(inmsg, outmsg)
+		if _, ok := config.EventMap["ingress.event.processblock"]; ok {
+			eventMsg = false
+			WriteProcessBlockedMsg(inmsg, outmsg)
+		} else {
+			return nil, nil
+		}
 	case cbMessage.Module != nil:
-		eventMsg = false
-		WriteModinfoMessage(inmsg, outmsg)
+		if _, ok := config.EventMap["ingress.event.module"]; ok {
+			eventMsg = false
+			WriteModinfoMessage(inmsg, outmsg)
+		} else {
+			return nil, nil
+		}
 	default:
 		// we ignore event types we don't understand yet.
 		return nil, nil


### PR DESCRIPTION
TLS changes to provide a way to override the CN when validating certificates as well as force TLSv1.2 when connecting to the target syslog/http and Cb Response servers