### PR TITLE
add missing fields for childprocs and a few other event types

### DIFF
--- a/pb_message_processor.go
+++ b/pb_message_processor.go
@@ -505,7 +505,7 @@ func WriteChildprocMessage(message *ConvertedCbMessage, kv map[string]interface{
 	kv["tamper_sent"] = om.Childproc.GetTamperSent()
 
 	childProctype := om.Childproc.GetChildProcType()
-	kv["type"] = childProcType(childProctype)
+	kv["child_proc_type"] = childProcType(childProctype)
 	kv["parent_guid"] = om.Childproc.GetParentGuid()
 	kv["child_guid"] = om.Childproc.GetChildGuid()
 

--- a/pb_message_processor.go
+++ b/pb_message_processor.go
@@ -467,7 +467,7 @@ func childProcType(a sensor_events.CbChildProcessMsg_CbChildProcType) string {
 	case sensor_events.CbChildProcessMsg_childProcFork:
 		return "fork"
 	case sensor_events.CbChildProcessMsg_childProcOtherExec:
-		return "other"
+		return "other_exec"
 	}
 	return fmt.Sprintf("unknown (%d)", int32(a))
 }

--- a/pb_message_processor.go
+++ b/pb_message_processor.go
@@ -460,18 +460,6 @@ func WriteFilemodMessage(message *ConvertedCbMessage, kv map[string]interface{})
 	kv["tamper_sent"] = message.OriginalMessage.Filemod.GetTamperSent()
 }
 
-func childProcType(a sensor_events.CbChildProcessMsg_CbChildProcType) string {
-	switch a {
-	case sensor_events.CbChildProcessMsg_childProcExec:
-		return "exec"
-	case sensor_events.CbChildProcessMsg_childProcFork:
-		return "fork"
-	case sensor_events.CbChildProcessMsg_childProcOtherExec:
-		return "other_exec"
-	}
-	return fmt.Sprintf("unknown (%d)", int32(a))
-}
-
 func WriteChildprocMessage(message *ConvertedCbMessage, kv map[string]interface{}) {
 	kv["event_type"] = "childproc"
 	kv["type"] = "ingress.event.childproc"

--- a/pb_message_processor.go
+++ b/pb_message_processor.go
@@ -504,8 +504,6 @@ func WriteChildprocMessage(message *ConvertedCbMessage, kv map[string]interface{
 	}
 
 	kv["path"] = om.Childproc.GetPath()
-
-
 	kv["md5"] = GetMd5Hexdigest(om.Childproc.GetMd5Hash())
 	kv["sha256"] = GetSha256Hexdigest(om.Childproc.GetSha256Hash())
 
@@ -516,8 +514,8 @@ func WriteChildprocMessage(message *ConvertedCbMessage, kv map[string]interface{
 	// handle suppressed children
 	if om.Childproc.Suppressed != nil &&
 		om.Childproc.Suppressed.GetBIsSuppressed() {
-		kv["suppressed"] = true
-		kv["child_command_line"] = om.Childproc.GetCommandline()
+		kv["child_suppressed"] = true
+		kv["child_command_line"] = GetUnicodeFromUTF8(om.Childproc.GetCommandline())
 		kv["child_username"] = om.Childproc.GetUsername()
 	} else {
 		kv["child_suppressed"] = false

--- a/pb_message_processor.go
+++ b/pb_message_processor.go
@@ -504,8 +504,8 @@ func WriteChildprocMessage(message *ConvertedCbMessage, kv map[string]interface{
 	kv["tamper"] = om.Childproc.GetTamper()
 	kv["tamper_sent"] = om.Childproc.GetTamperSent()
 
-	childProctype := om.Childproc.GetChildProcType()
-	kv["child_proc_type"] = childProcType(childProctype)
+	procType := om.Childproc.GetChildProcType()
+	kv["child_proc_type"] = childProcType(procType)
 	kv["parent_guid"] = om.Childproc.GetParentGuid()
 	kv["child_guid"] = om.Childproc.GetChildGuid()
 


### PR DESCRIPTION
This PR adds the following fields that are present in the protobuf def but the the event forwarder 

CbProcessMsg - parent_pid
CbProcessMsg - parent_guid
CbProcessMsg - filtering_known_dlls
CbProcessMsg - tamper
CbProcessMsg - tamper_sent

CbChildProcessMsg - tamper
CbChildProcessMsg - tamper_sent
CbChildProcessMsg - parent_guid

CbRegModMsg - tamper
CbRegModMsg - tamper_sent

