### PR TITLE
Create a config option for automatic vs manual acking

### DIFF
--- a/amqp.go
+++ b/amqp.go
@@ -93,7 +93,7 @@ func NewConsumer(amqpURI, queueName, ctag string, bindToRawExchange bool,
 	deliveries, err := c.channel.Consume(
 		queue.Name,
 		c.tag,
-		true,  // automatic ack
+		config.AMQPAutomaticAcking,  // automatic or manual acking
 		false, // exclusive
 		false, // noLocal
 		false, // noWait

--- a/conf/cb-event-forwarder.example.ini
+++ b/conf/cb-event-forwarder.example.ini
@@ -56,6 +56,38 @@ rabbit_mq_username=
 rabbit_mq_password=
 cb_server_hostname=
 
+# Rabbit MQ Acking
+# RabbitMQ has two options for acking events off of the message bus, automatic and manual.
+# The default for the Event Forwarder is automatic. In automatic acknowledgement mode, a
+# message is considered to be successfully delivered immediately after it is sent.
+# This mode trades off higher throughput (as long as the consumers can keep up)
+# for reduced safety of delivery and consumer processing. With manual acking, the
+# consumer must ack each individual event sent by the producer and an event will not
+# be considered sucessfully received until the consumer sends an ack to the producer.
+# See https://www.rabbitmq.com/confirms.html for a more detailed explination.
+# Automatic acking is reccomended as not all consumers can keep up with the rate of acking
+# that is required with high event environments. If manual acking is desired, please be
+# sure to make sure that your consumers can keep up with the number of acks necessary.
+# This can be done by increasing message_processor_count, using EnableRawSensorDataBroadcast
+# vs events_raw_sensor, and using rabbit_mq_queue_name while running multiple instances
+# of the Event Forwarder If rabbit_mq_automatic_acking is set to true then automatic mode
+# is used, if rabbit_mq_automatic_acking is false then manual mode will be used.
+# The default is true.
+rabbit_mq_automatic_acking=false
+
+
+# Rabbit MQ queue Name
+# The RabbitMQ queue name is the name of the queue that is created on the RabbitMQ server
+# from which the event forwarder will receive events. By default this name is made up of a static
+# string, the hostname of the machine it's running on, and the pid of the event forwarder process.
+# This mihgt not be desired in high throughput environments where it's necessary to run multiple instances
+# of the event forwarder in order to keep up with the volume of events coming off of the RabbitMQ event bus.
+# By setting rabbit_mq_queue_name to a static string the queue name will be the same across all running
+# instances of the event forwarder, allowing multiple instances of the event forwarder to consume from the
+# same RabbitMQ queue. The default is an empty string.
+#
+rabbit_mq_queue_name=
+
 #
 # The cb-event-forwarder can optionally place deep links into the JSON or LEEF output so users can have
 # one-click access to process, binary, or sensor context. For example, a watchlist process hit will now include:
@@ -478,4 +510,3 @@ events_storage_partition=0
 #hec_token stores the HEC token to be used when communicating with splunk
 #
 hec_token=PASSWORD
-

--- a/conf/cb-event-forwarder.example.ini
+++ b/conf/cb-event-forwarder.example.ini
@@ -58,29 +58,28 @@ cb_server_hostname=
 
 # Rabbit MQ Acking
 # RabbitMQ has two options for acking events off of the message bus, automatic and manual.
-# The default for the Event Forwarder is automatic. In automatic acknowledgement mode, a
-# message is considered to be successfully delivered immediately after it is sent.
-# This mode trades off higher throughput (as long as the consumers can keep up)
+# In automatic acknowledgement mode, a message is considered to be successfully delivered
+# immediately after it is sent. This mode trades off higher throughput (as long as the consumers can keep up)
 # for reduced safety of delivery and consumer processing. With manual acking, the
 # consumer must ack each individual event sent by the producer and an event will not
 # be considered sucessfully received until the consumer sends an ack to the producer.
 # See https://www.rabbitmq.com/confirms.html for a more detailed explination.
-# Automatic acking is reccomended as not all consumers can keep up with the rate of acking
-# that is required with high event environments. If manual acking is desired, please be
-# sure to make sure that your consumers can keep up with the number of acks necessary.
-# This can be done by increasing message_processor_count, using EnableRawSensorDataBroadcast
-# vs events_raw_sensor, and using rabbit_mq_queue_name while running multiple instances
-# of the Event Forwarder If rabbit_mq_automatic_acking is set to true then automatic mode
-# is used, if rabbit_mq_automatic_acking is false then manual mode will be used.
-# The default is true.
-rabbit_mq_automatic_acking=false
+# Automatic acking is recommended as not all environments can keep up with the rate of acking
+# that is required. If manual acking is desired, please be sure to make sure that your
+# consumers can keep up with the number of acks necessary. This can be done by increasing
+# message_processor_count, using EnableRawSensorDataBroadcast vs events_raw_sensor,
+# and using rabbit_mq_queue_name while running multiple instances of the Event Forwarder.
+# If rabbit_mq_automatic_acking is set to true then automatic mode is used, if
+# rabbit_mq_automatic_acking is false then manual mode will be used. The default is true.
+#
+rabbit_mq_automatic_acking=true
 
 
 # Rabbit MQ queue Name
 # The RabbitMQ queue name is the name of the queue that is created on the RabbitMQ server
 # from which the event forwarder will receive events. By default this name is made up of a static
 # string, the hostname of the machine it's running on, and the pid of the event forwarder process.
-# This mihgt not be desired in high throughput environments where it's necessary to run multiple instances
+# This might not be desired in high throughput environments where it's necessary to run multiple instances
 # of the event forwarder in order to keep up with the volume of events coming off of the RabbitMQ event bus.
 # By setting rabbit_mq_queue_name to a static string the queue name will be the same across all running
 # instances of the event forwarder, allowing multiple instances of the event forwarder to consume from the

--- a/config.go
+++ b/config.go
@@ -46,6 +46,7 @@ type Configuration struct {
 	AMQPTLSClientCert    string
 	AMQPTLSCACert        string
 	AMQPQueueName        string
+	AMQPAutomaticAcking  bool
 	OutputParameters     string
 	EventTypes           []string
 	EventMap             map[string]bool
@@ -97,7 +98,7 @@ type Configuration struct {
 	SplunkToken *string
 
 	RemoveFromOutput []string
-	AuditLog    bool
+	AuditLog         bool
 }
 
 type ConfigurationError struct {
@@ -342,6 +343,19 @@ func ParseConfig(fn string) (Configuration, error) {
 	rabbitQueueName, ok := input.Get("bridge", "rabbit_mq_queue_name")
 	if ok {
 		config.AMQPQueueName = rabbitQueueName
+	}
+
+	config.AMQPAutomaticAcking = true
+	rabbitManualAcking, ok := input.Get("bridge", "rabbit_mq_automatic_acking")
+	if ok {
+		boolval, err := strconv.ParseBool(rabbitManualAcking)
+		if err == nil {
+			if boolval == false {
+				config.AMQPAutomaticAcking = false
+			}
+		} else {
+			errs.addErrorString("Unknown value for 'rabbit_mq_automatic_acking': valid values are true, false, 1, 0. Default is 'true'")
+		}
 	}
 
 	val, ok = input.Get("bridge", "cb_server_hostname")

--- a/config.go
+++ b/config.go
@@ -346,9 +346,9 @@ func ParseConfig(fn string) (Configuration, error) {
 	}
 
 	config.AMQPAutomaticAcking = true
-	rabbitManualAcking, ok := input.Get("bridge", "rabbit_mq_automatic_acking")
+	rabbitAutomaticAcking, ok := input.Get("bridge", "rabbit_mq_automatic_acking")
 	if ok {
-		boolval, err := strconv.ParseBool(rabbitManualAcking)
+		boolval, err := strconv.ParseBool(rabbitAutomaticAcking)
 		if err == nil {
 			if boolval == false {
 				config.AMQPAutomaticAcking = false

--- a/config.go
+++ b/config.go
@@ -349,10 +349,8 @@ func ParseConfig(fn string) (Configuration, error) {
 	rabbitAutomaticAcking, ok := input.Get("bridge", "rabbit_mq_automatic_acking")
 	if ok {
 		boolval, err := strconv.ParseBool(rabbitAutomaticAcking)
-		if err == nil {
-			if boolval == false {
-				config.AMQPAutomaticAcking = false
-			}
+		if err == nil && boolval == false {
+			config.AMQPAutomaticAcking = false
 		} else {
 			errs.addErrorString("Unknown value for 'rabbit_mq_automatic_acking': valid values are true, false, 1, 0. Default is 'true'")
 		}
@@ -566,10 +564,8 @@ func ParseConfig(fn string) (Configuration, error) {
 	tlsVerify, ok := input.Get(outType, "tls_verify")
 	if ok {
 		boolval, err := strconv.ParseBool(tlsVerify)
-		if err == nil {
-			if boolval == false {
-				config.TLSVerify = false
-			}
+		if err == nil && boolval == false {
+			config.TLSVerify = false
 		} else {
 			errs.addErrorString("Unknown value for 'tls_verify': valid values are true, false, 1, 0. Default is 'true'")
 		}
@@ -579,10 +575,8 @@ func ParseConfig(fn string) (Configuration, error) {
 	tlsInsecure, ok := input.Get(outType, "insecure_tls")
 	if ok {
 		boolval, err := strconv.ParseBool(tlsInsecure)
-		if err == nil {
-			if boolval == true {
-				config.TLS12Only = false
-			}
+		if err == nil && boolval == false {
+			config.TLS12Only = false
 		} else {
 			errs.addErrorString("Unknown value for 'insecure_tls': ")
 		}
@@ -607,10 +601,8 @@ func ParseConfig(fn string) (Configuration, error) {
 	sendEmptyFiles, ok := input.Get(outType, "upload_empty_files")
 	if ok {
 		boolval, err := strconv.ParseBool(sendEmptyFiles)
-		if err == nil {
-			if boolval == false {
-				config.UploadEmptyFiles = false
-			}
+		if err == nil && boolval == false {
+			config.UploadEmptyFiles = false
 		} else {
 			errs.addErrorString("Unknown value for 'upload_empty_files': valid values are true, false, 1, 0. Default is 'true'")
 		}

--- a/config.go
+++ b/config.go
@@ -575,7 +575,7 @@ func ParseConfig(fn string) (Configuration, error) {
 	tlsInsecure, ok := input.Get(outType, "insecure_tls")
 	if ok {
 		boolval, err := strconv.ParseBool(tlsInsecure)
-		if err == nil && boolval == false {
+		if err == nil && boolval == true {
 			config.TLS12Only = false
 		} else {
 			errs.addErrorString("Unknown value for 'insecure_tls': ")


### PR DESCRIPTION
This adds a config option for manual acking, which might be desired in an environment to guarantee delivery.

This also exposes the `rabbit_mq_queue_name` config option in the config example which would be desired in a high throughput environment. 