### PR TITLE
Fix config logic parsing

### DIFF
--- a/config.go
+++ b/config.go
@@ -349,8 +349,10 @@ func ParseConfig(fn string) (Configuration, error) {
 	rabbitAutomaticAcking, ok := input.Get("bridge", "rabbit_mq_automatic_acking")
 	if ok {
 		boolval, err := strconv.ParseBool(rabbitAutomaticAcking)
-		if err == nil && boolval == false {
-			config.AMQPAutomaticAcking = false
+		if err == nil {
+			if boolval == false {
+				config.AMQPAutomaticAcking = false
+			}
 		} else {
 			errs.addErrorString("Unknown value for 'rabbit_mq_automatic_acking': valid values are true, false, 1, 0. Default is 'true'")
 		}
@@ -564,8 +566,10 @@ func ParseConfig(fn string) (Configuration, error) {
 	tlsVerify, ok := input.Get(outType, "tls_verify")
 	if ok {
 		boolval, err := strconv.ParseBool(tlsVerify)
-		if err == nil && boolval == false {
-			config.TLSVerify = false
+		if err == nil {
+			if boolval == false {
+				config.TLSVerify = false
+			}
 		} else {
 			errs.addErrorString("Unknown value for 'tls_verify': valid values are true, false, 1, 0. Default is 'true'")
 		}
@@ -575,8 +579,10 @@ func ParseConfig(fn string) (Configuration, error) {
 	tlsInsecure, ok := input.Get(outType, "insecure_tls")
 	if ok {
 		boolval, err := strconv.ParseBool(tlsInsecure)
-		if err == nil && boolval == true {
-			config.TLS12Only = false
+		if err == nil {
+			if boolval == true {
+				config.TLS12Only = false
+			}
 		} else {
 			errs.addErrorString("Unknown value for 'insecure_tls': ")
 		}
@@ -601,8 +607,10 @@ func ParseConfig(fn string) (Configuration, error) {
 	sendEmptyFiles, ok := input.Get(outType, "upload_empty_files")
 	if ok {
 		boolval, err := strconv.ParseBool(sendEmptyFiles)
-		if err == nil && boolval == false {
-			config.UploadEmptyFiles = false
+		if err == nil {
+			if boolval == false {
+				config.UploadEmptyFiles = false
+			}
 		} else {
 			errs.addErrorString("Unknown value for 'upload_empty_files': valid values are true, false, 1, 0. Default is 'true'")
 		}


### PR DESCRIPTION
This change was committed by me but broke things. I misunderstood the logic and it produces undesired outcomes. 

We want the `if` statements to only fall through to the else only if the `err == nil` does not pass.