### PR TITLE
Add config option to add additional key/value pairs

### DIFF
--- a/cmd/cb-event-forwarder/config.go
+++ b/cmd/cb-event-forwarder/config.go
@@ -97,6 +97,7 @@ type Configuration struct {
 	//Splunkd
 	SplunkToken *string
 
+	AddToOutput map[string]string
 	RemoveFromOutput []string
 	AuditLog         bool
 }
@@ -251,6 +252,22 @@ func ParseConfig(fn string) (Configuration, error) {
 			customFormatter.FullTimestamp = true
 
 			log.Debug("Debugging output is set to True")
+		}
+	}
+
+	config.AddToOutput = make(map[string]string)
+
+	addToOutput, ok := input.Get("bridge", "add_to_output")
+	if ok {
+		thingsToAdd := strings.Split(addToOutput, ",")
+
+		for _, element := range thingsToAdd {
+			keyValToAdd := strings.Split(element, "=")
+			if len(keyValToAdd) >= 2 {
+				key := strings.TrimSpace(keyValToAdd[0])
+				val := strings.TrimSpace(keyValToAdd[1])
+				config.AddToOutput[key] = val
+			}
 		}
 	}
 

--- a/cmd/cb-event-forwarder/main.go
+++ b/cmd/cb-event-forwarder/main.go
@@ -228,6 +228,11 @@ func outputMessage(msg map[string]interface{}) error {
 	//
 	msg["cb_server"] = config.ServerName
 
+	// Add key=value pairs that has been configured to be added
+	for key, val := range config.AddToOutput {
+		msg[key] = val
+	}
+
 	// Remove keys that have been configured to be removed
 	for _, v := range config.RemoveFromOutput {
 		delete(msg, v)

--- a/conf/cb-event-forwarder.example.ini
+++ b/conf/cb-event-forwarder.example.ini
@@ -124,6 +124,12 @@ rabbit_mq_queue_name=
 # api_token=
 
 #
+# add_to_output=some_metadata=value1,other_metadata=other_value
+#
+# comma separated list of key=value pairs to add to LEEF/JSON output
+add_to_output=
+
+#
 #remove_from_output=highlights_by_doc,stuff
 #
 #


### PR DESCRIPTION
This commit adds a setting `add_to_output` in the config, which allows one to add additional (static) metadata to events forwarded by the cb-event-forwarder.

The setting can be set to a sequence of key=value pairs, separated by commas. An example could be:

    [bridge]
    add_to_output=meta_location=some_city,meta_department=some_dept