### PR TITLE
Update timestamp precision

### DIFF
--- a/cmd/cb-event-forwarder/pb_message_processor.go
+++ b/cmd/cb-event-forwarder/pb_message_processor.go
@@ -235,6 +235,7 @@ func ProcessProtobufMessage(routingKey string, body []byte, headers amqp.Table) 
 
 	outmsg := make(map[string]interface{})
 	outmsg["timestamp"] = WindowsTimeToUnixTime(inmsg.OriginalMessage.Header.GetTimestamp())
+	outmsg["process_create_time"] = WindowsTimeToUnixTime(inmsg.OriginalMessage.Header.GetProcessCreateTime())
 	outmsg["type"] = routingKey
 
 	outmsg["sensor_id"] = cbMessage.Env.Endpoint.GetSensorId()

--- a/cmd/cb-event-forwarder/pb_message_processor.go
+++ b/cmd/cb-event-forwarder/pb_message_processor.go
@@ -495,9 +495,7 @@ func WriteChildprocMessage(message *ConvertedCbMessage, kv map[string]interface{
 	kv["type"] = "ingress.event.childproc"
 
 	kv["child_proc_type"] = message.OriginalMessage.Childproc.GetChildProcType()
-
-	kv["created"] = message.OriginalMessage.Childproc.GetCreated()
-
+	
 	om := message.OriginalMessage
 	kv["created"] = om.Childproc.GetCreated()
 

--- a/cmd/cb-event-forwarder/pb_message_processor.go
+++ b/cmd/cb-event-forwarder/pb_message_processor.go
@@ -490,6 +490,11 @@ func WriteFilemodMessage(message *ConvertedCbMessage, kv map[string]interface{})
 func WriteChildprocMessage(message *ConvertedCbMessage, kv map[string]interface{}) {
 	kv["event_type"] = "childproc"
 	kv["type"] = "ingress.event.childproc"
+
+	kv["child_proc_type"] = message.OriginalMessage.Childproc.GetChildProcType()
+
+	kv["created"] = message.OriginalMessage.Childproc.GetCreated()
+
 	om := message.OriginalMessage
 	kv["created"] = om.Childproc.GetCreated()
 

--- a/cmd/cb-event-forwarder/pb_message_processor.go
+++ b/cmd/cb-event-forwarder/pb_message_processor.go
@@ -344,7 +344,9 @@ func ProcessProtobufMessage(routingKey string, body []byte, headers amqp.Table) 
 		processGUID := GetProcessGUID(cbMessage)
 		outmsg["process_guid"] = processGUID
 		outmsg["pid"] = inmsg.OriginalMessage.Header.GetProcessPid()
-
+		if inmsg.OriginalMessage.Header.GetForkPid() != 0 {
+			outmsg["fork_pid"] = inmsg.OriginalMessage.Header.GetForkPid()
+		}
 		/*
 		 * Sometimes Process path is empty
 		 */

--- a/cmd/cb-event-forwarder/utils.go
+++ b/cmd/cb-event-forwarder/utils.go
@@ -15,19 +15,23 @@ import (
  * conversion routines
  */
 
-func WindowsTimeToUnixTime(windowsTime int64) int64 {
+func WindowsTimeToUnixTime(windowsTime int64) float64 {
+
 	// number of milliseconds between Jan 1st 1601 and Jan 1st 1970
 	var timeShift int64
 	timeShift = 11644473600000
-
+	
 	if windowsTime == 0 {
-		return windowsTime
+		return float64(windowsTime)
 	}
 
 	windowsTime /= 10000     // ns to ms
 	windowsTime -= timeShift // since 1601 to since 1970
-	windowsTime /= 1000
-	return windowsTime
+	var windowsTimeFloat float64
+	windowsTimeFloat = float64(windowsTime)
+	windowsTimeFloat /= 1000
+	return windowsTimeFloat
+
 }
 
 func MakeGUID(sensorID, pid int32, createTime int64) string {


### PR DESCRIPTION
Update timestamp to millisecond precision, using a float64.

Add fork_pid, process_create_time, child_proc_type to the outgoing event.