### PR TITLE
Add support for s3 from ipv6 networks

### DIFF
--- a/cmd/cb-event-forwarder/config.go
+++ b/cmd/cb-event-forwarder/config.go
@@ -59,6 +59,7 @@ type Configuration struct {
 	S3CredentialProfileName *string
 	S3ACLPolicy             *string
 	S3ObjectPrefix          *string
+	S3UseDualStack          bool
 
 	// SSL/TLS-specific configuration
 	TLSClientKey  *string
@@ -444,6 +445,14 @@ func ParseConfig(fn string) (Configuration, error) {
 			objectPrefix, ok := input.Get("s3", "object_prefix")
 			if ok {
 				config.S3ObjectPrefix = &objectPrefix
+			}
+
+			useDualStack, ok := input.Get("s3", "use_dual_stack")
+			if ok {
+				b, err := strconv.ParseBool(useDualStack)
+				if err == nil {
+					config.S3UseDualStack = b
+				}
 			}
 
 		case "http":

--- a/cmd/cb-event-forwarder/s3_behavior.go
+++ b/cmd/cb-event-forwarder/s3_behavior.go
@@ -70,6 +70,10 @@ func (o *S3Behavior) Initialize(connString string) error {
 	}
 
 	awsConfig := &aws.Config{Region: aws.String(o.region)}
+	if config.S3UseDualStack == true {
+		awsConfig.WithUseDualStack(true)
+	}
+
 	if config.S3CredentialProfileName != nil {
 		parts = strings.SplitN(*config.S3CredentialProfileName, ":", 2)
 		credentialProvider := credentials.SharedCredentialsProvider{}

--- a/conf/cb-event-forwarder.example.ini
+++ b/conf/cb-event-forwarder.example.ini
@@ -379,6 +379,10 @@ events_storage_partition=0
 # This is useful if multiple forwarders are to use the same s3 bucket
 # object_prefix=objectname
 
+# Enables "dual stack" endpoints for the S3 client. This is necessary for environments that only have
+# ipv6 networking. Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/dual-stack-endpoints.html
+# use_dual_stack=true
+
 [syslog]
 # Uncomment ca_cert to specify a file containing PEM-encoded CA certificates for verifying the peer
 # server when using TLS+TCP syslog


### PR DESCRIPTION
Writing to s3 from an ipv6-only network requires the use of "dual stack" endpoints (see more [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/dual-stack-endpoints.html)). This PR adds an option in the config to use dual stack endpoints and then passes that option to the S3 client when it is created.