### PR TITLE
Support outputing EventText as byte array field

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,6 +42,10 @@
   version = "1.0.0"
 
 [[constraint]]
+  branch = "master"
+  name = "github.com/google/go-cmp"
+
+[[constraint]]
   name = "github.com/hpcloud/tail"
   version = "1.0.0"
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test:
 	rm -rf test_output/leef_output
 	mkdir test_output/gold_output
 	python test/scripts/process_events_python.py test/raw_data test_output/gold_output
-	go test ./cmd/cb-event-forwarder
+	go test -tags static ./cmd/cb-event-forwarder
 	PYTHONIOENCODING=utf8 python test/scripts/compare_outputs.py test_output/gold_output test_output/go_output > test_output/output.txt
 
 clean:

--- a/cmd/cb-event-forwarder/config.go
+++ b/cmd/cb-event-forwarder/config.go
@@ -71,9 +71,10 @@ type Configuration struct {
 	TLS12Only     bool
 
 	// HTTP-specific configuration
-	HTTPAuthorizationToken *string
-	HTTPPostTemplate       *template.Template
-	HTTPContentType        *string
+	HTTPAuthorizationToken   *string
+	HTTPPostTemplate         *template.Template
+	HTTPContentType          *string
+	EventTextAsJsonByteArray bool
 
 	// configuration options common to bundled outputs (S3, HTTP)
 	UploadEmptyFiles    bool
@@ -485,6 +486,16 @@ func ParseConfig(fn string) (Configuration, error) {
 			} else {
 				jsonString := "application/json"
 				config.HTTPContentType = &jsonString
+			}
+
+			eventTextAsJsonByteArray, ok := input.Get("http", "event_text_as_json_byte_array")
+			if ok {
+				boolval, err := strconv.ParseBool(eventTextAsJsonByteArray)
+				if err == nil {
+					config.EventTextAsJsonByteArray = boolval
+				} else {
+					errs.addErrorString(fmt.Sprintf("Invalid event_text_as_json_byte_array: %s", eventTextAsJsonByteArray))
+				}
 			}
 		case "syslog":
 			parameterKey = "syslogout"

--- a/cmd/cb-event-forwarder/http_util.go
+++ b/cmd/cb-event-forwarder/http_util.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
-	log "github.com/sirupsen/logrus"
+	"encoding/base64"
 	"io"
 	"os"
 	"text/template"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type UploadData struct {
@@ -66,7 +68,7 @@ func convertFileIntoTemplate(fp *os.File, events chan<- UploadEvent, firstEventT
 			log.Debug(err)
 		}
 
-		events <- UploadEvent{EventText: eventText, EventSeq: i}
+		events <- newUploadEvent(i, eventText, config.EventTextAsJsonByteArray)
 		i++
 
 	}
@@ -75,4 +77,16 @@ func convertFileIntoTemplate(fp *os.File, events chan<- UploadEvent, firstEventT
 		log.Debug(err)
 	}
 
+}
+
+// newUploadEvent creates an instance of UploadEvent.
+func newUploadEvent(eventSeq int64, eventText string, eventTextAsJsonByteArray bool) UploadEvent {
+	// If eventTextAsJsonByteArray is true, eventText will be encoded as a base64-encoded string.
+	if eventTextAsJsonByteArray {
+		eventText = base64.StdEncoding.EncodeToString([]byte(eventText))
+	}
+	return UploadEvent{
+		EventSeq:  eventSeq,
+		EventText: eventText,
+	}
 }

--- a/cmd/cb-event-forwarder/http_util_test.go
+++ b/cmd/cb-event-forwarder/http_util_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func TestNewUploadEvent(t *testing.T) {
+	for _, test := range []struct {
+		desc                     string
+		eventSeq                 int64
+		eventText                string
+		eventTextAsJsonByteArray bool
+		expectedUploadEvent      UploadEvent
+	}{
+		{
+			desc:                     "eventTextAsJsonByteArray false, empty eventText",
+			eventSeq:                 1,
+			eventText:                "",
+			eventTextAsJsonByteArray: false,
+			expectedUploadEvent: UploadEvent{
+				EventSeq:  1,
+				EventText: "",
+			},
+		},
+		{
+			desc:                     "eventTextAsJsonByteArray false, non-empty eventText",
+			eventSeq:                 1,
+			eventText:                "some event",
+			eventTextAsJsonByteArray: false,
+			expectedUploadEvent: UploadEvent{
+				EventSeq:  1,
+				EventText: "some event",
+			},
+		},
+		{
+			desc:                     "eventTextAsJsonByteArray true, empty eventText",
+			eventSeq:                 1,
+			eventText:                "",
+			eventTextAsJsonByteArray: true,
+			expectedUploadEvent: UploadEvent{
+				EventSeq:  1,
+				EventText: "",
+			},
+		},
+		{
+			desc:                     "eventTextAsJsonByteArray true, non-empty eventText",
+			eventSeq:                 1,
+			eventText:                "some event",
+			eventTextAsJsonByteArray: true,
+			expectedUploadEvent: UploadEvent{
+				EventSeq:  1,
+				EventText: "c29tZSBldmVudA==",
+			},
+		},
+	} {
+		test := test // capture range variable.
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			gotUploadEvent := newUploadEvent(test.eventSeq, test.eventText, test.eventTextAsJsonByteArray)
+			if diff := cmp.Diff(gotUploadEvent, test.expectedUploadEvent); diff != "" {
+				t.Errorf("uploadEvent different from expected, diff: %s", diff)
+			}
+		})
+	}
+}

--- a/cmd/cb-event-forwarder/main.go
+++ b/cmd/cb-event-forwarder/main.go
@@ -40,7 +40,7 @@ type Status struct {
 	InputEventCount  *expvar.Int
 	OutputEventCount *expvar.Int
 	ErrorCount       *expvar.Int
-	OutputEventRate *expvar.Float
+	OutputEventRate  *expvar.Float
 
 	IsConnected     bool
 	LastConnectTime time.Time
@@ -288,7 +288,7 @@ func logFileProcessingLoop() <-chan error {
 		}
 
 		for delivery := range deliveries {
-			log.Debug("Trying to deliver log message %s", delivery)
+			log.Debugf("Trying to deliver log message %s", delivery)
 			msgMap := make(map[string]interface{})
 			msgMap["message"] = strings.TrimSuffix(delivery, "\n")
 			msgMap["type"] = label

--- a/conf/cb-event-forwarder.example.ini
+++ b/conf/cb-event-forwarder.example.ini
@@ -463,6 +463,14 @@ events_storage_partition=0
 #  for more information. By default no Authorization header is sent.
 # authorization_token=Basic QWxhZGRpbjpPcGVuU2VzYW1l
 
+# Uncomment event_text_as_json_byte_array to output EventText as byte array field (i.e. binary field)
+# when posting JSON to the remote service.
+# Definition of EventText field in UploadEvent struct can be found in http_util.go.
+# By default, EventText is output as JSON string field and the value of EventText will be in UTF-8
+# encoded string. If EventText is output as JSON byte array field, the value of EventText will be
+# in base64-encoded string.
+# event_text_as_json_byte_array=false
+
 [kafka]
 # Uncomment when using kafka brokers. Broker configuration should be a comma-separated
 # list of brokers with ports.


### PR DESCRIPTION
Support outputing EventText as byte array field (i.e. binary field) when posting JSON to the remote service.

By default, EventText is output as JSON string field and the value of
EventText will be in UTF-8 encoded string. If EventText is output as
JSON byte array field, the value of EventText will be in base64-encoded string.