### PR TITLE
Add OAuth 2.0 JSON Web Token flow support to http output

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,6 +42,10 @@
   version = "1.0.0"
 
 [[constraint]]
+  branch = "master"
+  name = "github.com/google/go-cmp"
+
+[[constraint]]
   name = "github.com/hpcloud/tail"
   version = "1.0.0"
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test:
 	rm -rf test_output/leef_output
 	mkdir test_output/gold_output
 	python test/scripts/process_events_python.py test/raw_data test_output/gold_output
-	go test ./cmd/cb-event-forwarder
+	go test -tags static ./cmd/cb-event-forwarder
 	PYTHONIOENCODING=utf8 python test/scripts/compare_outputs.py test_output/gold_output test_output/go_output > test_output/output.txt
 
 clean:

--- a/cmd/cb-event-forwarder/config_test.go
+++ b/cmd/cb-event-forwarder/config_test.go
@@ -1,0 +1,342 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	ini "github.com/vaughan0/go-ini"
+)
+
+func TestParseOAuthConfiguration(t *testing.T) {
+	for _, test := range []struct {
+		desc           string
+		input          *ini.File
+		config         *Configuration
+		errs           *ConfigurationError
+		expectedConfig *Configuration
+		expectedErrs   *ConfigurationError
+	}{
+		{
+			desc: "All OAuth fields configured",
+			input: &ini.File{
+				"http": {
+					"oauth_jwt_client_email":   "example@serviceaccount.com",
+					"oauth_jwt_private_key":    "private_key",
+					"oauth_jwt_private_key_id": "private_key_id",
+					"oauth_jwt_scopes":         "scope_1,scope2",
+					"oauth_jwt_token_url":      "https://example.com/oauth2/token",
+				},
+			},
+			config: &Configuration{},
+			errs:   &ConfigurationError{Empty: true},
+			expectedConfig: &Configuration{
+				OAuthJwtClientEmail:  "example@serviceaccount.com",
+				OAuthJwtPrivateKey:   []byte("private_key"),
+				OAuthJwtPrivateKeyId: "private_key_id",
+				OAuthJwtScopes:       []string{"scope_1", "scope2"},
+				OAuthJwtTokenUrl:     "https://example.com/oauth2/token",
+			},
+			expectedErrs: &ConfigurationError{Empty: true},
+		},
+		{
+			desc: "Only required OAuth fields configured",
+			input: &ini.File{
+				"http": {
+					"oauth_jwt_client_email": "example@serviceaccount.com",
+					"oauth_jwt_private_key":  "private_key",
+					"oauth_jwt_token_url":    "https://example.com/oauth2/token",
+				},
+			},
+			config: &Configuration{},
+			errs:   &ConfigurationError{Empty: true},
+			expectedConfig: &Configuration{
+				OAuthJwtClientEmail: "example@serviceaccount.com",
+				OAuthJwtPrivateKey:  []byte("private_key"),
+				OAuthJwtTokenUrl:    "https://example.com/oauth2/token",
+			},
+			expectedErrs: &ConfigurationError{Empty: true},
+		},
+		{
+			desc: "Replace the escaped version of line break character to the non-escaped version",
+			input: &ini.File{
+				"http": {
+					"oauth_jwt_client_email":   "example@serviceaccount.com",
+					"oauth_jwt_private_key":    "-----BEGIN PRIVATE KEY-----\\nVcgdkPBHC\\n-----END PRIVATE KEY-----\\n",
+					"oauth_jwt_private_key_id": "private_key_id",
+					"oauth_jwt_scopes":         "scope_1,scope2",
+					"oauth_jwt_token_url":      "https://example.com/oauth2/token",
+				},
+			},
+			config: &Configuration{},
+			errs:   &ConfigurationError{Empty: true},
+			expectedConfig: &Configuration{
+				OAuthJwtClientEmail:  "example@serviceaccount.com",
+				OAuthJwtPrivateKey:   []byte("-----BEGIN PRIVATE KEY-----\nVcgdkPBHC\n-----END PRIVATE KEY-----\n"),
+				OAuthJwtPrivateKeyId: "private_key_id",
+				OAuthJwtScopes:       []string{"scope_1", "scope2"},
+				OAuthJwtTokenUrl:     "https://example.com/oauth2/token",
+			},
+			expectedErrs: &ConfigurationError{Empty: true},
+		},
+	} {
+		test := test // capture range variable.
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			errs := test.errs
+			config := test.config
+			parseOAuthConfiguration(test.input, config, errs)
+
+			if diff := cmp.Diff(config, test.expectedConfig); diff != "" {
+				t.Errorf("config different from expected, diff: %s", diff)
+			}
+
+			if diff := cmp.Diff(errs, test.expectedErrs); diff != "" {
+				t.Errorf("errors different from expected, diff: %s", diff)
+			}
+		})
+	}
+}
+
+func TestParseOAuthConfigurationErrors(t *testing.T) {
+	for _, test := range []struct {
+		desc           string
+		input          *ini.File
+		config         *Configuration
+		errs           *ConfigurationError
+		expectedConfig *Configuration
+		expectedErrs   *ConfigurationError
+	}{
+		{
+			desc: "Empty value for oauth_jwt_client_email",
+			input: &ini.File{
+				"http": {
+					"oauth_jwt_client_email":   "",
+					"oauth_jwt_private_key":    "private_key",
+					"oauth_jwt_private_key_id": "private_key_id",
+					"oauth_jwt_scopes":         "scope_1,scope2",
+					"oauth_jwt_token_url":      "https://example.com/oauth2/token",
+				},
+			},
+			config: &Configuration{},
+			errs:   &ConfigurationError{Empty: true},
+			expectedConfig: &Configuration{
+				OAuthJwtPrivateKey:   []byte("private_key"),
+				OAuthJwtPrivateKeyId: "private_key_id",
+				OAuthJwtScopes:       []string{"scope_1", "scope2"},
+				OAuthJwtTokenUrl:     "https://example.com/oauth2/token",
+			},
+			expectedErrs: &ConfigurationError{
+				Errors: []string{
+					"Empty value is specified for oauth_jwt_client_email",
+					"Required OAuth field oauth_jwt_client_email is not configured",
+				},
+			},
+		},
+		{
+			desc: "Empty value for oauth_jwt_private_key",
+			input: &ini.File{
+				"http": {
+					"oauth_jwt_client_email":   "example@serviceaccount.com",
+					"oauth_jwt_private_key":    "",
+					"oauth_jwt_private_key_id": "private_key_id",
+					"oauth_jwt_scopes":         "scope_1,scope2",
+					"oauth_jwt_token_url":      "https://example.com/oauth2/token",
+				},
+			},
+			config: &Configuration{},
+			errs:   &ConfigurationError{Empty: true},
+			expectedConfig: &Configuration{
+				OAuthJwtClientEmail:  "example@serviceaccount.com",
+				OAuthJwtPrivateKeyId: "private_key_id",
+				OAuthJwtScopes:       []string{"scope_1", "scope2"},
+				OAuthJwtTokenUrl:     "https://example.com/oauth2/token",
+			},
+			expectedErrs: &ConfigurationError{
+				Errors: []string{
+					"Empty value is specified for oauth_jwt_private_key",
+					"Required OAuth field oauth_jwt_private_key is not configured",
+				},
+			},
+		},
+		{
+			desc: "Empty value for oauth_jwt_private_key_id",
+			input: &ini.File{
+				"http": {
+					"oauth_jwt_client_email":   "example@serviceaccount.com",
+					"oauth_jwt_private_key":    "private_key",
+					"oauth_jwt_private_key_id": "",
+					"oauth_jwt_scopes":         "scope_1,scope2",
+					"oauth_jwt_token_url":      "https://example.com/oauth2/token",
+				},
+			},
+			config: &Configuration{},
+			errs:   &ConfigurationError{Empty: true},
+			expectedConfig: &Configuration{
+				OAuthJwtClientEmail: "example@serviceaccount.com",
+				OAuthJwtPrivateKey:  []byte("private_key"),
+				OAuthJwtScopes:      []string{"scope_1", "scope2"},
+				OAuthJwtTokenUrl:    "https://example.com/oauth2/token",
+			},
+			expectedErrs: &ConfigurationError{
+				Errors: []string{
+					"Empty value is specified for oauth_jwt_private_key_id",
+				},
+			},
+		},
+		{
+			desc: "Empty value for oauth_jwt_scopes",
+			input: &ini.File{
+				"http": {
+					"oauth_jwt_client_email":   "example@serviceaccount.com",
+					"oauth_jwt_private_key":    "private_key",
+					"oauth_jwt_private_key_id": "private_key_id",
+					"oauth_jwt_scopes":         "",
+					"oauth_jwt_token_url":      "https://example.com/oauth2/token",
+				},
+			},
+			config: &Configuration{},
+			errs:   &ConfigurationError{Empty: true},
+			expectedConfig: &Configuration{
+				OAuthJwtClientEmail:  "example@serviceaccount.com",
+				OAuthJwtPrivateKey:   []byte("private_key"),
+				OAuthJwtPrivateKeyId: "private_key_id",
+				OAuthJwtTokenUrl:     "https://example.com/oauth2/token",
+			},
+			expectedErrs: &ConfigurationError{
+				Errors: []string{
+					"Empty value is specified for oauth_jwt_scopes",
+				},
+			},
+		},
+		{
+			desc: "Empty value for oauth_jwt_token_url",
+			input: &ini.File{
+				"http": {
+					"oauth_jwt_client_email":   "example@serviceaccount.com",
+					"oauth_jwt_private_key":    "private_key",
+					"oauth_jwt_private_key_id": "private_key_id",
+					"oauth_jwt_scopes":         "scope_1,scope2",
+					"oauth_jwt_token_url":      "",
+				},
+			},
+			config: &Configuration{},
+			errs:   &ConfigurationError{Empty: true},
+			expectedConfig: &Configuration{
+				OAuthJwtClientEmail:  "example@serviceaccount.com",
+				OAuthJwtPrivateKey:   []byte("private_key"),
+				OAuthJwtPrivateKeyId: "private_key_id",
+				OAuthJwtScopes:       []string{"scope_1", "scope2"},
+			},
+			expectedErrs: &ConfigurationError{
+				Errors: []string{
+					"Empty value is specified for oauth_jwt_token_url",
+					"Required OAuth field oauth_jwt_token_url is not configured",
+				},
+			},
+		},
+		{
+			desc: "Missing required field: oauth_jwt_client_email",
+			input: &ini.File{
+				"http": {
+					"oauth_jwt_private_key": "private_key",
+					"oauth_jwt_token_url":   "https://example.com/oauth2/token",
+				},
+			},
+			config: &Configuration{},
+			errs:   &ConfigurationError{Empty: true},
+			expectedConfig: &Configuration{
+				OAuthJwtPrivateKey: []byte("private_key"),
+				OAuthJwtTokenUrl:   "https://example.com/oauth2/token",
+			},
+			expectedErrs: &ConfigurationError{
+				Errors: []string{
+					"Required OAuth field oauth_jwt_client_email is not configured",
+				},
+			},
+		},
+		{
+			desc: "Missing required field: oauth_jwt_private_key",
+			input: &ini.File{
+				"http": {
+					"oauth_jwt_client_email": "example@serviceaccount.com",
+					"oauth_jwt_token_url":    "https://example.com/oauth2/token",
+				},
+			},
+			config: &Configuration{},
+			errs:   &ConfigurationError{Empty: true},
+			expectedConfig: &Configuration{
+				OAuthJwtClientEmail: "example@serviceaccount.com",
+				OAuthJwtTokenUrl:    "https://example.com/oauth2/token",
+			},
+			expectedErrs: &ConfigurationError{
+				Errors: []string{
+					"Required OAuth field oauth_jwt_private_key is not configured",
+				},
+			},
+		},
+		{
+			desc: "Missing required field: oauth_jwt_token_url",
+			input: &ini.File{
+				"http": {
+					"oauth_jwt_client_email": "example@serviceaccount.com",
+					"oauth_jwt_private_key":  "private_key",
+				},
+			},
+			config: &Configuration{},
+			errs:   &ConfigurationError{Empty: true},
+			expectedConfig: &Configuration{
+				OAuthJwtClientEmail: "example@serviceaccount.com",
+				OAuthJwtPrivateKey:  []byte("private_key"),
+			},
+			expectedErrs: &ConfigurationError{
+				Errors: []string{
+					"Required OAuth field oauth_jwt_token_url is not configured",
+				},
+			},
+		},
+		{
+			desc: "oauth_jwt_scopes contains empty scope",
+			input: &ini.File{
+				"http": {
+					"oauth_jwt_client_email":   "example@serviceaccount.com",
+					"oauth_jwt_private_key":    "private_key",
+					"oauth_jwt_private_key_id": "private_key_id",
+					"oauth_jwt_scopes":         "scope_1, ",
+					"oauth_jwt_token_url":      "https://example.com/oauth2/token",
+				},
+			},
+			config: &Configuration{},
+			errs:   &ConfigurationError{Empty: true},
+			expectedConfig: &Configuration{
+				OAuthJwtClientEmail:  "example@serviceaccount.com",
+				OAuthJwtPrivateKey:   []byte("private_key"),
+				OAuthJwtPrivateKeyId: "private_key_id",
+				OAuthJwtScopes:       []string{"scope_1"},
+				OAuthJwtTokenUrl:     "https://example.com/oauth2/token",
+			},
+			expectedErrs: &ConfigurationError{
+				Errors: []string{
+					"Empty scope found",
+				},
+			},
+		},
+	} {
+		test := test // capture range variable.
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			errs := test.errs
+			config := test.config
+			parseOAuthConfiguration(test.input, config, errs)
+
+			if diff := cmp.Diff(config, test.expectedConfig); diff != "" {
+				t.Errorf("config different from expected, diff: %s", diff)
+			}
+
+			if diff := cmp.Diff(errs, test.expectedErrs); diff != "" {
+				t.Errorf("errors different from expected, diff: %s", diff)
+			}
+		})
+	}
+}

--- a/cmd/cb-event-forwarder/http_behavior_test.go
+++ b/cmd/cb-event-forwarder/http_behavior_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestCreateTransport(t *testing.T) {
+	for _, test := range []struct {
+		desc         string
+		config       Configuration
+		expectedType reflect.Type
+	}{
+		{
+			desc: "oauth2.Transport",
+			config: Configuration{
+				OAuthJwtClientEmail: "example@serviceaccount.com",
+				OAuthJwtPrivateKey:  []byte("private_key"),
+				OAuthJwtTokenUrl:    "https://example.com/oauth2/token",
+			},
+			expectedType: reflect.TypeOf(&oauth2.Transport{}),
+		},
+		{
+			desc:         "http.Transport",
+			config:       Configuration{},
+			expectedType: reflect.TypeOf(&http.Transport{}),
+		},
+	} {
+		test := test // capture range variable.
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			transport := createTransport(test.config)
+			if reflect.TypeOf(transport) != test.expectedType {
+				t.Errorf("type of transport: %s, want: %s", reflect.TypeOf(transport), test.expectedType)
+			}
+		})
+	}
+}

--- a/cmd/cb-event-forwarder/main.go
+++ b/cmd/cb-event-forwarder/main.go
@@ -40,7 +40,7 @@ type Status struct {
 	InputEventCount  *expvar.Int
 	OutputEventCount *expvar.Int
 	ErrorCount       *expvar.Int
-	OutputEventRate *expvar.Float
+	OutputEventRate  *expvar.Float
 
 	IsConnected     bool
 	LastConnectTime time.Time
@@ -288,7 +288,7 @@ func logFileProcessingLoop() <-chan error {
 		}
 
 		for delivery := range deliveries {
-			log.Debug("Trying to deliver log message %s", delivery)
+			log.Debugf("Trying to deliver log message %s", delivery)
 			msgMap := make(map[string]interface{})
 			msgMap["message"] = strings.TrimSuffix(delivery, "\n")
 			msgMap["type"] = label

--- a/conf/cb-event-forwarder.example.ini
+++ b/conf/cb-event-forwarder.example.ini
@@ -463,6 +463,33 @@ events_storage_partition=0
 #  for more information. By default no Authorization header is sent.
 # authorization_token=Basic QWxhZGRpbjpPcGVuU2VzYW1l
 
+# Uncomment fields which prefixed with oauth_jwt_ to use the OAuth 2.0 JSON Web Token flow, commonly
+# known as "two-legged OAuth 2.0". See: https://tools.ietf.org/html/draft-ietf-oauth-jwt-bearer-12
+# for more information.
+#
+# [Required OAuth field] oauth_jwt_client_email is the Oauth client identifier used when
+# communicating with the configured OAuth provider.
+# oauth_jwt_client_email=example@serviceaccount.com
+
+# [Required OAuth field] oauth_jwt_private_key contains the contents of a RSA private key or the
+# contents of a PEM file that contains a private key. The provided private key is used to sign JWT
+# payloads. PEM containers with a passphrase are not supported. Use the following command to convert
+# a PKCS 12 file into a PEM.
+# $ openssl pkcs12 -in key.p12 -out key.pem -nodes
+# oauth_jwt_private_key=private_key
+
+# [Required OAuth field] oauth_jwt_token_url is the endpoint required to complete the 2-legged JWT
+# flow.
+# oauth_jwt_token_url=https://example.com/oauth2/token
+
+# [Optional OAuth field] oauth_jwt_private_key_id contains a hint indicating which key is being
+# used.
+# oauth_jwt_private_key_id=private_key_id
+
+# [Optional OAuth field] oauth_jwt_scopes specifies a comma-separated list of requested permission
+# scopes.
+# oauth_jwt_scopes=scope_1,scope_2
+
 [kafka]
 # Uncomment when using kafka brokers. Broker configuration should be a comma-separated
 # list of brokers with ports.


### PR DESCRIPTION
To learn more about OAuth 2.0 JSON Web Token flow, please refer to
https://tools.ietf.org/html/draft-ietf-oauth-jwt-bearer-12.