### PR TITLE
Change build from "static" to "static all"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,14 @@ build: librdkafka
 	go mod tidy
 	protoc --gogofast_out=.  ./internal/sensor_events/sensor_events.proto
 	go mod verify
-	go build -tags static ./cmd/cb-event-forwarder 
-	go build -tags static ./cmd/kafka-util
+	go build -tags static-all ./cmd/cb-event-forwarder
+	go build -tags static-all ./cmd/kafka-util
 
 rpmbuild: librdkafka
 	go get -u github.com/gogo/protobuf/protoc-gen-gogofast
 	protoc --gogofast_out=.  ./internal/sensor_events/sensor_events.proto
-	go build -tags static -ldflags "-X main.version=${VERSION}" ./cmd/cb-event-forwarder
-	go build -tags static -ldflags "-X main.version=${VERSION}" ./cmd/kafka-util
+	go build -tags static-all -ldflags "-X main.version=${VERSION}" ./cmd/cb-event-forwarder
+	go build -tags static-all -ldflags "-X main.version=${VERSION}" ./cmd/kafka-util
 
 rpminstall:
 	mkdir -p ${RPM_BUILD_ROOT}/usr/share/cb/integrations/event-forwarder

--- a/go.mod
+++ b/go.mod
@@ -23,10 +23,10 @@ require (
 	github.com/streadway/amqp v0.0.0-20180315184602-8e4aba63da9f
 	github.com/stretchr/testify v1.3.0
 	github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec
-	golang.org/x/crypto v0.0.0-20190927123631-a832865fa7ad // indirect
-	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17 // indirect
+	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc // indirect
+	golang.org/x/net v0.0.0-20191002035440-2ec189313ef0 // indirect
 	golang.org/x/oauth2 v0.0.0-20190212230446-3e8b2be13635
-	golang.org/x/sys v0.0.0-20190927073244-c990c680b611 // indirect
+	golang.org/x/sys v0.0.0-20191002091554-b397fe3ad8ed // indirect
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/h2non/filetype.v1 v1.0.5


### PR DESCRIPTION
This seems to give us a more easily-installable RPM, at least on CentOS 7.