### PR TITLE
Building docker fails on pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN yum install -y zlib zlib-devel cyrus-sasl-devel openssl-devel
 
 RUN yum install -y lsof
 RUN yum install -y python-devel python-pip
+
+RUN pip install --upgrade pip
 RUN pip install pika cbapi
 
 #build forwarder


### PR DESCRIPTION
I have added one `RUN` command to mitigate issue with `pip` package dependencies
`RUN pip install --upgrade pip`

```
Step 20/25 : RUN pip install pika cbapi
 ---> Running in 41ae84f32784
Collecting pika
  Downloading https://files.pythonhosted.org/packages/a1/ae/8bedf0e9f1c0c5d046db3a7428a4227fe36ec1b8e25607f3c38ac9bf513c/pika-1.1.0-py2.py3-none-any.whl (148kB)
Collecting cbapi
  Downloading https://files.pythonhosted.org/packages/90/81/999a1fce3b288ca8cff5309a7f55089da555c66655650ad7a4321ad6daec/cbapi-1.5.5.tar.gz (190kB)
Collecting requests (from cbapi)
  Downloading https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl (57kB)
Collecting attrdict (from cbapi)
  Downloading https://files.pythonhosted.org/packages/ef/97/28fe7e68bc7adfce67d4339756e85e9fcf3c6fd7f0c0781695352b70472c/attrdict-2.0.1-py2.py3-none-any.whl
Collecting cachetools (from cbapi)
  Downloading https://files.pythonhosted.org/packages/2f/a6/30b0a0bef12283e83e58c1d6e7b5aabc7acfc4110df81a4471655d33e704/cachetools-3.1.1-py2.py3-none-any.whl
Collecting pyyaml (from cbapi)
  Downloading https://files.pythonhosted.org/packages/e3/e8/b3212641ee2718d556df0f23f78de8303f068fe29cdaa7a91018849582fe/PyYAML-5.1.2.tar.gz (265kB)
Collecting prompt_toolkit (from cbapi)
  Downloading https://files.pythonhosted.org/packages/66/6a/2c0693ec21528c10dfea279662788b28b2a01cce961160791084d975521a/prompt_toolkit-2.0.10-py2-none-any.whl (340kB)
Collecting pygments (from cbapi)
  Downloading https://files.pythonhosted.org/packages/5c/73/1dfa428150e3ccb0fa3e68db406e5be48698f2a979ccbcec795f28f44048/Pygments-2.4.2-py2.py3-none-any.whl (883kB)
Collecting pytest<=5.0 (from cbapi)
  Downloading https://files.pythonhosted.org/packages/b7/a9/e64eae45880d383120ef258e23136c74ecd0757ecae84491b578eabaa562/pytest-5.0.0.tar.gz (947kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-4zxph0/pytest/setup.py", line 40, in <module>
        main()
      File "/tmp/pip-build-4zxph0/pytest/setup.py", line 35, in main
        install_requires=INSTALL_REQUIRES,
      File "/usr/lib64/python2.7/distutils/core.py", line 112, in setup
        _setup_distribution = dist = klass(attrs)
      File "/usr/lib/python2.7/site-packages/setuptools/dist.py", line 265, in __init__
        self.fetch_build_eggs(attrs.pop('setup_requires'))
      File "/usr/lib/python2.7/site-packages/setuptools/dist.py", line 289, in fetch_build_eggs
        parse_requirements(requires), installer=self.fetch_build_egg
      File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 630, in resolve
        raise VersionConflict(dist,req) # XXX put more info here
    pkg_resources.VersionConflict: (setuptools 0.9.8 (/usr/lib/python2.7/site-packages), Requirement.parse('setuptools>=40.0'))

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-4zxph0/pytest/
You are using pip version 8.1.2, however version 19.3.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
The command '/bin/sh -c pip install pika cbapi' returned a non-zero code: 1
```

BTW it's best practice to lock `pip` package versions
BTW `python2` is considered deprecated and will reach the end of its life on January 1st, 2020