### PR TITLE
CB-30713: Fixing NotifClose support in amqp consumer

### DIFF
--- a/cmd/cb-event-forwarder/amqp.go
+++ b/cmd/cb-event-forwarder/amqp.go
@@ -4,9 +4,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io/ioutil"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/streadway/amqp"
-	"io/ioutil"
 )
 
 /*
@@ -66,6 +67,7 @@ func NewConsumer(amqpURI, queueName, ctag string, bindToRawExchange bool,
 		dialer:            dialer,
 		amqpURI:           amqpURI,
 		queueName:         queueName,
+		connectionErrors:  make(chan *amqp.Error),
 		tlsCfg:            getAMQPTLSConfigFromConf()}
 
 	return c

--- a/cmd/cb-event-forwarder/amqp.go
+++ b/cmd/cb-event-forwarder/amqp.go
@@ -58,6 +58,11 @@ func (wrappedcon WrappedAMQPConnection) Channel() (AMQPChannel, error) {
 
 func NewConsumer(amqpURI, queueName, ctag string, bindToRawExchange bool,
 	routingKeys []string, dialer AMQPDialer) *Consumer {
+	return NewConsumerWithTlsCfg(amqpURI, queueName, ctag, bindToRawExchange, routingKeys, dialer, getAMQPTLSConfigFromConf())
+}
+
+func NewConsumerWithTlsCfg(amqpURI, queueName, ctag string, bindToRawExchange bool,
+	routingKeys []string, dialer AMQPDialer, tlsCfg *tls.Config) *Consumer {
 	c := &Consumer{
 		conn:              nil,
 		channel:           nil,
@@ -68,7 +73,7 @@ func NewConsumer(amqpURI, queueName, ctag string, bindToRawExchange bool,
 		amqpURI:           amqpURI,
 		queueName:         queueName,
 		connectionErrors:  make(chan *amqp.Error),
-		tlsCfg:            getAMQPTLSConfigFromConf()}
+		tlsCfg:            tlsCfg}
 
 	return c
 }

--- a/cmd/cb-event-forwarder/amqp_test.go
+++ b/cmd/cb-event-forwarder/amqp_test.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestNewConsumer(t *testing.T) {
+	c := NewConsumerWithTlsCfg("amqp://lol:lol@cb/", "aqueuename", "consumertag", true, []string{"aroutingkey", "anotherroutingkey"}, MockAMQPDialer{}, nil)
+	if c.connectionErrors == nil {
+		t.Errorf("ConnectionError channel not constructed properly")
+	}
+}

--- a/cmd/cb-event-forwarder/main.go
+++ b/cmd/cb-event-forwarder/main.go
@@ -9,13 +9,6 @@ import (
 	"expvar"
 	"flag"
 	"fmt"
-	"github.com/carbonblack/cb-event-forwarder/internal/leef"
-	"github.com/carbonblack/cb-event-forwarder/internal/sensor_events"
-	"github.com/cyberdelia/go-metrics-graphite"
-	"github.com/rcrowley/go-metrics"
-	"github.com/rcrowley/go-metrics/exp"
-	log "github.com/sirupsen/logrus"
-	"github.com/streadway/amqp"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -24,9 +17,17 @@ import (
 	"strings"
 	"sync"
 	"time"
-)
 
-import _ "net/http/pprof"
+	"github.com/carbonblack/cb-event-forwarder/internal/leef"
+	"github.com/carbonblack/cb-event-forwarder/internal/sensor_events"
+	graphite "github.com/cyberdelia/go-metrics-graphite"
+	"github.com/rcrowley/go-metrics"
+	"github.com/rcrowley/go-metrics/exp"
+	log "github.com/sirupsen/logrus"
+	"github.com/streadway/amqp"
+
+	_ "net/http/pprof"
+)
 
 var (
 	checkConfiguration = flag.Bool("check", false, "Check the configuration file and exit")
@@ -307,6 +308,7 @@ func outputMessage(msg map[string]interface{}) error {
 }
 
 func splitDelivery(deliveries <-chan amqp.Delivery, messages chan<- amqp.Delivery) {
+	defer close(messages)
 	for delivery := range deliveries {
 		messages <- delivery
 	}


### PR DESCRIPTION
Fix a bug in the amqp consumer where NotifyClose wasn't working. Should address CB-30713 and the related escalation, based on my testing.

You can test this by running the rabbitmq management interface, and force-closing the aqmp connection from the event-forwarder. 