### PR TITLE
CB-30580: add timestamps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 #GIT_VERSION := $(shell git describe --tags)
 #VERSION := $(shell cat VERSION)
 
-GIT_VERSION := 3.6.1
-VERSION := 3.6.1
+GIT_VERSION := 3.6.2
+VERSION := 3.6.2
 GO_PREFIX := github.com/carbonblack/cb-event-forwarder
 EL_VERSION := $(shell rpm -E %{rhel})
 TARGET_OS=linux

--- a/cb-event-forwarder.rpm.spec
+++ b/cb-event-forwarder.rpm.spec
@@ -27,7 +27,7 @@ The events can be saved to a file, delivered to a network service or archived au
 These events can be consumed by any external system that accepts JSON or LEEF, including Splunk and IBM QRadar.
 
 %prep
-%setup -n %{name}-%{version}
+%setup -n %{name}-%{bare_version}
 
 %build
 export GOPATH=$PWD

--- a/cb-event-forwarder.rpm.spec
+++ b/cb-event-forwarder.rpm.spec
@@ -4,7 +4,7 @@
 %global __os_install_post /usr/lib/rpm/brp-compress %{nil}
 
 %define bare_version 3.6.2
-%define build_timestamp %(date +%%y%%m%%d)
+%define build_timestamp %(date +%%y%%m%%d.%%H%%m)
 %define release 0
 
 Summary: Carbon Black event forwarder

--- a/cb-event-forwarder.rpm.spec
+++ b/cb-event-forwarder.rpm.spec
@@ -3,15 +3,15 @@
 %global debug_package %{nil}
 %global __os_install_post /usr/lib/rpm/brp-compress %{nil}
 
-%define version 3.6.2
+%define bare_version 3.6.2
 %define build_timestamp %(date +%%y%%m%%d)
 %define release 0
 
 Summary: Carbon Black event forwarder
 Name: %{name}
-Version: %{version}.%{build_timestamp}
+Version: %{bare_version}.%{build_timestamp}
 Release: %{release}%{?dist}
-Source0: %{name}-%{version}.tar.gz
+Source0: %{name}-%{bare_version}.tar.gz
 License: MIT
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot

--- a/cb-event-forwarder.rpm.spec
+++ b/cb-event-forwarder.rpm.spec
@@ -3,12 +3,13 @@
 %global debug_package %{nil}
 %global __os_install_post /usr/lib/rpm/brp-compress %{nil}
 
-%define version 3.6.1
+%define version 3.6.2
+%define build_timestamp %(date +%%y%%m%%d)
 %define release 0
 
 Summary: Carbon Black event forwarder
 Name: %{name}
-Version: %{version}
+Version: %{version}.%{build_timestamp}
 Release: %{release}%{?dist}
 Source0: %{name}-%{version}.tar.gz
 License: MIT


### PR DESCRIPTION
RPMs now include a timestamp, e.g. `cb-event-forwarder-3.6.2.200319.1303-0.el6.x86_64.rpm`. I also bumped the version to 3.6.2