### PR TITLE
CB-30786: Jenkins script to deploy build to Artifactory-QA

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,5 +35,3 @@ require (
 	gopkg.in/ini.v1 v1.41.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -35,3 +35,5 @@ require (
 	gopkg.in/ini.v1 v1.41.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )
+
+go 1.13

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+if [[ -z "${__af_user}" || -z "${__af_api_key}" || -z "${__af_base_url}" ]]
+then
+  echo -e '\nRequired variables not defined\n'
+  return 1
+fi
+
+parse_pkg_to_path() {
+  if [[ -n "$1" ]]
+  then
+    pkg=$1
+    filename=${pkg##*/}
+    rx='cb-event-forwarder-([0-9\.]+)-[0-9]\.el([0-9]).+'
+    if [[ ${filename} =~ ${rx} ]]
+    then
+      ver="${BASH_REMATCH[1]}"
+      plat="el${BASH_REMATCH[2]}"
+      PKG_FILE=${pkg}
+      PARSED_PATH="${plat}/${ver}/${filename}"
+      return 0
+    else
+      PKG_FILE=
+      PARSED_PATH=
+      return 1
+    fi
+  else
+    PKG_FILE=
+    PARSED_PATH=
+    return 1
+  fi
+}
+
+deploy_to_artifactory() {
+  if [[ -n "$1" && -n "$2" ]]
+  then
+    _pkg_path=$1
+    _branch=$2
+    parse_pkg_to_path ${_pkg_path}
+    if [[ $? -eq 0 ]]
+    then
+      curl -u ${__af_user}:${__af_api_key} ${__af_base_url}/${_branch}/${PARSED_PATH} -T ${PKG_FILE}
+      if [[ $? -eq 1 ]]
+      then
+        echo -e '\nDeployment failed\n'
+        return 1
+      fi
+    else
+      echo -e '\nPackage name parsing failed\n'
+      return 1
+    fi
+  else
+    echo -e '\nInsufficient arguments\n'
+    return 1
+  fi
+  echo -e '\nSuccess\n'
+  return 0
+}


### PR DESCRIPTION
The script is intended to be sourced into the Build section of a Jenkins job within an "Execute shell" build step. Once it has been sourced, we can use the `deploy_to_artifactory` function to perform the deployment to artifactory-qa. This function takes one argument, which the the path (which may be relative) to the RPM file to be deployed). We're checking it into the source code to make it easier to maintain through git.

RPMs are deployed to the path `cb-event-forwarder/<branch>/<platform>/<version>` on Artifactory-QA.

The script depends on three "secret" variables that specify the Jenkins API user, API key, and base URL. These would be inserted directly into the Jenkins build step -- we don't want to put them into the script file itself, because this is an opensource project (and even if it wasn't, it's a better practice not to reveal this data in the source code).

Here is a driver script that can be used for testing. It assumes that it resides in the same directory as the script in this PR.

```
#!/usr/bin/env bash

#
# SEE JIRA TICKET FOR REQUIRED VARIABLES
# 

. ./deploy
if [[ $? -eq 1 ]]
then
  echo "Error loading deployment functions"
  exit 1
fi

if [[ -z "$1" || -z "$2" ]]
then
  echo "Usage: $0 PACKAGE_FILE_PATH BRANCH"
  exit 1
fi

echo "Deploying $2:$1 to Artifactory"
deploy_to_artifactory $1 $2
exit $?
```
