### PR TITLE
CB-31911: Remove deprecated config options from sample config file

### DIFF
--- a/conf/cb-event-forwarder.example.ini
+++ b/conf/cb-event-forwarder.example.ini
@@ -88,7 +88,7 @@ rabbit_mq_automatic_acking=true
 rabbit_mq_queue_name=
 
 #
-# The cb-event-forwarder can optionally place deep links into the JSON or LEEF output so users can have
+# The cb-event-forwarder will place deep links into the JSON or LEEF output so users can have
 # one-click access to process, binary, or sensor context. For example, a watchlist process hit will now include:
 #  .docs[0].link_sensor: https://cbtests/#/host/7
 #  .docs[0].link_process: https://cbtests/#analyze/00000007-0000-0fd4-01d1-209aa22a57ee/1
@@ -97,31 +97,12 @@ rabbit_mq_queue_name=
 #
 # Raw endpoint events will include a "link_process", and binary watchlist hits will include a "link_md5"
 #
-# To enable these links, uncomment and place the base URL of your EDR server into the cb_server_url variable
+# Uncomment and place the base URL of your EDR server into the cb_server_url variable
 # below.
 
-# The cb_server_url is also used for any post processing that requires the EDR Server's REST API access.
+# The cb_server_url will be defaulted to the FQDN of the host on which the event-forwarder is runnning
 #
 # cb_server_url=https://my.company.cb.server
-
-#
-# Post Processing Options
-#
-# Supported post processing:
-#
-# 1) report_title in feed hits
-#
-# Post processing requires cb_server_url, api_verify_ssl, and api_token to be set.  The post processed messages are
-# dispatched to retrieve additional information from the EDR REST API.  Once the information is retrieved they
-# are placed in the ouput queue.
-#
-# SSL/TLS verification for connections to the EDR REST API
-#
-# api_verify_ssl=false
-#
-# The API Token to use when querying the EDR REST API
-#
-# api_token=
 
 #
 #remove_from_output=highlights_by_doc,stuff

--- a/conf/cb-event-forwarder.example.ini
+++ b/conf/cb-event-forwarder.example.ini
@@ -97,11 +97,9 @@ rabbit_mq_queue_name=
 #
 # Raw endpoint events will include a "link_process", and binary watchlist hits will include a "link_md5"
 #
-# Uncomment and place the base URL of your EDR server into the cb_server_url variable
-# below.
 
-# The cb_server_url will be defaulted to the FQDN of the host on which the event-forwarder is runnning
-#
+# The cb_server_url will default to the FQDN of the host on which the event-forwarder is installed
+# Uncomment and place the base URL of your EDR server into the cb_server_url variable below to override this behavior.
 # cb_server_url=https://my.company.cb.server
 
 #


### PR DESCRIPTION
Removes 3 deprecated config options that were used in the api-callbacks for report-title enrichment which were removed in CB-31411. 'api_url' , 'api-token', 'api_verify_ssl' - also cleans up some language in the sample config file to indicate that the cb_server_url will be set to the fqdn of the host by default. 