### PR TITLE
CB-32965: Make EF protect httpoutput against misconfiguration

### DIFF
--- a/cmd/cb-event-forwarder/config.go
+++ b/cmd/cb-event-forwarder/config.go
@@ -913,6 +913,11 @@ func ParseConfig(fn string) (Configuration, error) {
 
 	config.parseEventTypes(input)
 
+	outputParameterError := config.validateOutputParameters()
+	if outputParameterError != nil {
+		errs.addError(outputParameterError)
+	}
+
 	if !errs.Empty {
 		return config, errs
 	}
@@ -964,6 +969,18 @@ func configureTLS(config Configuration) *tls.Config {
 	}
 
 	return tlsConfig
+}
+
+func (c * Configuration) validateOutputParameters() error {
+	outputParameter := c.OutputParameters
+	switch (c.OutputType) {
+		case HTTPOutputType:
+			if !(strings.HasPrefix(outputParameter, "http://") || strings.HasPrefix(outputParameter, "https://")) {
+				return fmt.Errorf("Output destination for HTTP/s must include the protocol prefix http(s)://")
+			}
+
+	}
+	return nil
 }
 
 // parseOAuthConfiguration parses OAuth related configuration from input and populates config with


### PR DESCRIPTION
Adds output destination validation for the HTTP/S output - preventing the user from starting the forwarder with a misconfigured `httpout` key. The startup/config checks will fail and return an error when the destination is lacking the http(s):// protocol part. 