### PR TITLE
Update pb_message_processor.go

### DIFF
--- a/cmd/cb-event-forwarder/pb_message_processor.go
+++ b/cmd/cb-event-forwarder/pb_message_processor.go
@@ -119,7 +119,7 @@ func ProcessRawZipBundle(routingKey string, body []byte, headers amqp.Table) ([]
 
         newMsgs, err := ProcessProtobufBundle(routingKey, unzippedFile, headers)
         if err != nil {
-            log.Errorf("Error processing zip filename %s: %s", zf.Name, err.Error())
+            log.Debugf("Error processing zip filename %s: %s", zf.Name, err.Error())
 
             if config.DebugFlag {
                 // using anonymous func to encapsulate the defers


### PR DESCRIPTION
Remove last error level logger statement in pb message processor which causes log-spam on instances which see it repeatedly