### PR TITLE
Fix handling of JSON-encoded input messages

### DIFF
--- a/pkg/forwarder/input_worker.go
+++ b/pkg/forwarder/input_worker.go
@@ -67,13 +67,17 @@ func (inputWorker InputWorker) processMessage(body []byte, routingKey, contentTy
 		}
 
 		jsonMsgs, err := inputWorker.ProcessJSONMessage(msg, routingKey)
-		if err == nil {
-			for jsonMsg := range jsonMsgs {
-				jsonBytes, err := json.Marshal(jsonMsg)
-				if err == nil {
-					msgs = append(msgs, jsonBytes)
-				}
+		if err != nil {
+			inputWorker.reportError(string(body), "Unable to process JSON message", err)
+			return
+		}
+		for idx, jsonMsg := range jsonMsgs {
+			jsonBytes, err := json.Marshal(jsonMsg)
+			if err != nil {
+				inputWorker.reportError(string(body), fmt.Sprintf("Error encoding message at position %d", idx), err)
+				continue
 			}
+			msgs = append(msgs, jsonBytes)
 		}
 
 	default:


### PR DESCRIPTION
A bug was causing messages received with `content_type: application/json` to be delivered as a number, due to the message index being encoded instead of the message itself.

Sending a testing message:

```
$ rabbitmqadmin publish routing_key=test exchange=api.events properties='{"content_type":"application/json"}' payload_encoding='string' payload="{[...]}"
```

The following message is forwarded (using syslog output as an example)

before this fix:
```
<6> 2021-09-15T17:21:17+02:00 localhost ./cb-event-forwarder[11844]: 0
```

after this fix:
```
<6> 2021-09-15T17:20:11+02:00 localhost ./cb-event-forwarder[11424]: {"cb_server":"cbserver","deviceInfo": [...]}
```