### PR TITLE
Start service after network is actually up

### DIFF
--- a/cb-event-forwarder.service
+++ b/cb-event-forwarder.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=CB EDR Event Forwarder
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
network.target is not sufficient for ensuring the network is actually up. Switch to network-online.target instead.