### PR TITLE
Added support for SCRAM and TLS transport with kafka

### DIFF
--- a/conf/cb-event-forwarder.example.ini
+++ b/conf/cb-event-forwarder.example.ini
@@ -542,6 +542,12 @@ compress_http_payload=false
 # Optional custom kafka topic
 # topic = mytopic
 
+# Optional usage of SCRAM, supports SCRAM-SHA-256 and SCRAM-SHA-512
+# algorithm = SCRAM-SHA-256
+
+# Optinal usage of TLS for transport (NOT client auth)
+# use_tls_transport = true
+
 [splunk]
 # Uncomment ca_cert to specify a file containing PEM-encoded CA certificates for verifying the peer server
 # ca_cert=/etc/cb/integrations/event-forwarder/ca-certs.pem

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -152,6 +152,9 @@ type Configuration struct {
 	KafkaSSLCertificateLocation *string
 	KafkaSSLCALocation          *string
 
+    KafkaAlgorithm       string
+    KafkaUseTLSTransport bool
+
 	// Splunkd
 	SplunkToken *string
 
@@ -825,6 +828,18 @@ func (config *Configuration) parseKafkaSettings(input *ini.File) {
 		SSLKeyLocation := key.Value()
 		config.KafkaSSLKeyLocation = &SSLKeyLocation
 	}
+    if input.Section("kafka").HasKey("algorithm") {
+        key := input.Section("kafka").Key("algorithm")
+        kafkaAlgorithm := key.Value()
+        config.KafkaAlgorithm = kafkaAlgorithm
+    }
+    if input.Section("kafka").HasKey("use_tls_transport") {
+        key := input.Section("kafka").Key("use_tls_transport")
+        config.KafkaUseTLSTransport = false
+        if key.Value() == "true" {
+            config.KafkaUseTLSTransport = true
+        }
+    }
 }
 
 func (config *Configuration) parseSplunkSettings(input *ini.File) {


### PR DESCRIPTION
For kafka output:
- Added support for SCRAM authentication mechanisms.
- Added support for TLS transport without having to use client certificates.

Two new configuration options which is documented in the example.ini config file.