### PR TITLE
fix bug where tamper open filemod events were not mapped correctly to their string value

### DIFF
--- a/pkg/protobufmessageprocessor/new_protobuf_message_processor.go
+++ b/pkg/protobufmessageprocessor/new_protobuf_message_processor.go
@@ -1125,6 +1125,8 @@ func filemodAction(a CbFileModMsg_CbFileModAction) string {
 		return "delete"
 	case CbFileModMsg_actionFileModLastWrite:
 		return "lastwrite"
+	case CbFileModMsg_actionFileModOpen:
+		return "open"
 	}
 	return fmt.Sprintf("unknown (%d)", int32(a))
 }


### PR DESCRIPTION
Currently any incoming open filemod events are left unmapped, and their string value appears as `unknown (16)`.  The intent of this PR is to correctly map this using the generated protobuf code, the proto source for this enum value is [here](https://github.com/carbonblack/cb-event-forwarder/blob/develop/pkg/sensorevents/sensor_events.proto#L123-L123).